### PR TITLE
Chore: Remove unused imports and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ To set up the development environment and run tests:
 2.  **Run tests:**
     To execute the test suite, run:
     ```bash
-    poetry run task test
+    poetry run pytest
     ```
-    This command uses `taskipy` (defined in `pyproject.toml`) to invoke `pytest`.
+    This command directly invokes `pytest` using Poetry's script execution capabilities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,8 @@ dnspython = "^2.6.1" # Added dnspython
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.0"
-taskipy = "^1.12.2"
 pytest-asyncio = "^0.23.0" # Added pytest-asyncio
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.taskipy.tasks]
-test = "pytest"

--- a/tests/test_key_bindings.py
+++ b/tests/test_key_bindings.py
@@ -1,6 +1,4 @@
 import pytest
-import asyncio
-from textual.pilot import Pilot
 from email_host_lookup.email_host_lookup_screen import EmailHostLookupApp
 
 # Copied and adapted function:


### PR DESCRIPTION
This commit cleans up the codebase by:
1. Removing unused imports:
    - `import asyncio` and `from textual.pilot import Pilot` were removed from `tests/test_key_bindings.py` as they were not strictly necessary for its execution.
2. Removing unused dependencies:
    - The `taskipy` development dependency was removed from `pyproject.toml`.
    - The `[tool.taskipy.tasks]` configuration was removed from `pyproject.toml`.
3. Updating documentation:
    - The test execution command in `README.md` was updated from `poetry run task test` to `poetry run pytest` to reflect the removal of `taskipy`.

All tests pass after these changes, ensuring the application remains stable.